### PR TITLE
Load tramp before using it

### DIFF
--- a/multi-term.el
+++ b/multi-term.el
@@ -628,6 +628,7 @@ Similar to how `quoted-insert' works in a regular buffer."
 (defun multi-term-switch-buffer (term-buffer default-dir)
   "If we are in `tramp-mode', switch to TERM-BUFFER based on DEFAULT-DIR."
   (switch-to-buffer term-buffer)
+  (require 'tramp)
   (when (tramp-tramp-file-p default-dir)
     (with-parsed-tramp-file-name default-dir path
       (let ((method (cadr (assoc `tramp-login-program (assoc path-method tramp-methods)))))


### PR DESCRIPTION
This PR addresses an error I get when `multi-term` is invoked:

```
Debugger entered--Lisp error: (void-function tramp-tramp-file-p)
  tramp-tramp-file-p("/home/hlissner/.emacs.d/")
  multi-term-switch-buffer(#<buffer *terminal<1>*> "/home/hlissner/.emacs.d/")
  multi-term()
  funcall-interactively(multi-term)
  call-interactively(multi-term record nil)
  command-execute(multi-term record)
  execute-extended-command(nil "multi-term" "multi-term")
  funcall-interactively(execute-extended-command nil "multi-term" "multi-term")
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```

Tested in vanilla Emacs 26.3 with the following:

```elisp
(require 'multi-term) ; assuming multi-term has been installed
(call-interactively 'multi-term)
```